### PR TITLE
Remove unnecessary mkdir to remove extra image layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM nodesource/nsolid:boron-latest
 
-RUN mkdir -p /usr/src/app
-
 WORKDIR /usr/src/app
 
 ENV NODE_ENV production


### PR DESCRIPTION
> If the [WORKDIR](https://docs.docker.com/engine/reference/builder/#workdir) doesn’t exist, it will be created even if it’s not used in any subsequent Dockerfile instruction.